### PR TITLE
Add 2021 to version mappings

### DIFF
--- a/photoshop/api/constants.py
+++ b/photoshop/api/constants.py
@@ -1,5 +1,6 @@
 # The photoshop version to COM progid mappings.
 PHOTOSHOP_VERSION_MAPPINGS = {
+    "2021": "150",
     "2020": "140",
     "2019": "130",
     "2018": "120",


### PR DESCRIPTION
另外我注意到 `_core.py` 的 L30 直接指定了使用注册表取可用版本作为回滚方案，这会导致我输入任何不在 mappings 里的版本都会回滚到 PC 上安装的第一个可用版本，请问这是 by-design feature 吗