### PR TITLE
refactor(ActionDescriptor,ActionList,ActionReference): improve type communication

### DIFF
--- a/photoshop/api/__init__.py
+++ b/photoshop/api/__init__.py
@@ -2,9 +2,9 @@
 
 # Import local modules
 from photoshop.api import constants
-from photoshop.api.action_descriptor import ActionDescriptor
-from photoshop.api.action_list import ActionList
-from photoshop.api.action_reference import ActionReference
+from photoshop.api._actionmanager_type_binder import ActionDescriptor
+from photoshop.api._actionmanager_type_binder import ActionList
+from photoshop.api._actionmanager_type_binder import ActionReference
 from photoshop.api.application import Application
 from photoshop.api.colors import CMYKColor
 from photoshop.api.colors import GrayColor

--- a/photoshop/api/_actionmanager_type_binder.py
+++ b/photoshop/api/_actionmanager_type_binder.py
@@ -1,0 +1,61 @@
+"""This file enables type communication without circular import.
+
+We just put type-irrelevant codes in one file then inherit it in this file and add type-relevant codes.
+
+"""
+
+
+# Import local modules
+from photoshop.api.action_descriptor import ActionDescriptor as AD_proto
+from photoshop.api.action_list import ActionList as AL_proto
+from photoshop.api.action_reference import ActionReference as AR_proto
+from photoshop.api.enumerations import DescValueType
+from photoshop.api.enumerations import ReferenceFormType
+
+
+class ActionDescriptor(AD_proto):
+    def getType(self, key: int) -> DescValueType:
+        """Gets the type of a key."""
+        return DescValueType(self.app.getType(key))
+
+    def getObjectValue(self, key: int) -> "ActionDescriptor":
+        """Gets the value of a key of type object."""
+        return ActionDescriptor(parent=self.app.getObjectValue(key))
+
+    def getList(self, key: int) -> "ActionList":
+        """Gets the value of a key of type list."""
+        return ActionList(parent=self.app.getList(key))
+
+    def getReference(self, key: int) -> "ActionReference":
+        """Gets the value of a key of type ActionReference."""
+        return ActionReference(parent=self.app.getReference(key))
+
+
+class ActionList(AL_proto):
+    def getType(self, index: int) -> DescValueType:
+        """Gets the type of a list element."""
+        return DescValueType(self.app.getType(index))
+
+    def getObjectValue(self, index: int) -> "ActionDescriptor":
+        """Gets the value of a list element of type object."""
+        return ActionDescriptor(parent=self.app.getObjectValue(index))
+
+    def getList(self, index: int) -> "ActionList":
+        """Gets the value of a list element of type list."""
+        return ActionList(parent=self.app.getList(index))
+
+    def getReference(self, index: int) -> "ActionReference":
+        """Gets the value of a list element of type ActionReference."""
+        return ActionReference(parent=self.app.getReference(index))
+
+
+class ActionReference(AR_proto):
+    def getForm(self) -> ReferenceFormType:
+        """Gets the form of this action reference."""
+        return ReferenceFormType(self.app.getForm())
+
+    def getContainer(self) -> "ActionReference":
+        """Gets a reference contained in this reference.
+        Container references provide additional pieces to the reference.
+        This looks like another reference, but it is actually part of the same reference."""
+        return ActionReference(parent=self.app.getContainer())

--- a/photoshop/api/action_descriptor.py
+++ b/photoshop/api/action_descriptor.py
@@ -1,4 +1,4 @@
-"""A record of key-text_font pairs for actions.
+"""A record of key-data pairs for actions.
 
 such as those included on the Adobe Photoshop Actions menu.
 The ActionDescriptor class is part of the Action
@@ -8,27 +8,32 @@ see the Photoshop Scripting Guide.
 """
 
 # Import built-in modules
-from pathlib import Path
+from abc import ABC
+from abc import abstractmethod
+import pathlib
+import warnings
+
+# Import third-party modules
+import comtypes
 
 # Import local modules
 from photoshop.api._core import Photoshop
-from photoshop.api.action_list import ActionList
-from photoshop.api.action_reference import ActionReference
-from photoshop.api.enumerations import DescValueType
 
 
-class ActionDescriptor(Photoshop):
-    """A record of key-value pairs for actions, such as those included on the Adobe Photoshop Actions menu.
+DATAFUNC_WARN = """fromSteam, toStream, getData, putData is seldom performed successfully (even in native js, for
+example https://github.com/drsong2000/CRYENGINE/blob/release/Tools/photoshop/UltimateTextureSaver/Install/xtools/xlib/
+xml/atn2bin.jsx#L753-L769), and is deprecated. In fact, searching in github shows that these 4 functions are barely
+used in regular photoshop scripting. If you have found the criteria of these functions, please open an issue."""
 
-    The ActionDescriptor class is part of the Action Manager functionality.
-    For more details on the Action Manager, see the Photoshop Scripting Guide.
 
-    """
+class ActionDescriptor(Photoshop, ABC):
+    """This object provides a dictionary-style mechanism for storing data as key-value pairs. It can be used for
+    low-level access into Photoshop."""
 
     object_name = "ActionDescriptor"
 
-    def __init__(self):
-        super().__init__()
+    def __init__(self, parent: comtypes.client.lazybind.Dispatch = None):
+        super().__init__(parent=parent)
 
     @property
     def count(self):
@@ -39,118 +44,116 @@ class ActionDescriptor(Photoshop):
         """Clears the descriptor."""
         self.app.clear()
 
+    def isEqual(self, otherDesc):
+        """Determines whether the descriptor is the same as another descriptor."""
+        assert otherDesc.typename == "ActionDescriptor"
+        return self.app.isEqual(otherDesc)
+
+    def __eq__(self, other):
+        try:
+            return self.isEqual(other)
+        except AssertionError:
+            return False
+
     def erase(self, key: int):
-        """Erases a key form the descriptor."""
-        self.app.erase(key)
+        """Erases a key from the descriptor."""
+        self.erase(key)
 
     def fromStream(self, value: str):
-        """Create a descriptor from a stream of bytes.
+        """Creates a descriptor from a stream of bytes; for reading from disk."""
+        warnings.warn(DATAFUNC_WARN, category=PendingDeprecationWarning)
+        try:
+            self.app.fromStream(bytes.decode(value))
+        except BaseException:
+            pass
 
-        for reading from disk.
+    def toStream(self) -> str:
+        """Gets the entire descriptor as a stream of bytes, for writing to disk."""
+        warnings.warn(DATAFUNC_WARN, category=PendingDeprecationWarning)
+        try:
+            return self.app.toStream()
+        except BaseException:
+            return None
 
-        """
-        self.app.fromStream(value)
+    def getKey(self, index: int) -> int:
+        """Gets the ID of the Nth key, provided by index."""
+        return self.app.getKey(index)
 
-    def getBoolean(self, key: int) -> int:
-        """Gets the text_font of a key of type boolean.
-
-        Args:
-            key (str): key of type boolean.
-
-        Returns:
-            bool: The text_font of a key of type boolean.
-
-        """
+    def getBoolean(self, key: int) -> bool:
+        """Gets the value of a key of type boolean."""
         return self.app.getBoolean(key)
 
-    def getClass(self, key):
-        """Gets the text_font of a key of type class.
-
-        Args:
-            key (str): The key of type class.
-
-        Returns:
-            int: The text_font of a key of type class.
-
-        """
+    def getClass(self, key: int) -> int:
+        """Gets the value of a key of type class."""
         return self.app.getClass(key)
 
-    def getData(self, key: int) -> int:
+    def getData(self, key: int) -> str:
         """Gets raw byte data as a string value."""
-        return self.app.getData(key)
+        warnings.warn(DATAFUNC_WARN, category=PendingDeprecationWarning)
+        try:
+            return self.app.getData(key)
+        except BaseException:
+            return None
 
-    def getDouble(self, key: int) -> int:
+    def getDouble(self, key: int) -> float:
         """Gets the value of a key of type double."""
         return self.app.getDouble(key)
 
-    def getEnumerationType(self, index: int) -> int:
+    def getEnumerationType(self, key: int) -> int:
         """Gets the enumeration type of a key."""
-        return self.app.getEnumerationType(index)
+        return self.app.getEnumerationType(key)
 
-    def getEnumerationValue(self, index: int) -> int:
+    def getEnumerationValue(self, key: int) -> int:
         """Gets the enumeration value of a key."""
-        return self.app.getEnumerationValue(index)
+        return self.app.getEnumerationValue(key)
 
-    def getInteger(self, index: int) -> int:
+    def getInteger(self, key: int) -> int:
         """Gets the value of a key of type integer."""
-        return self.app.getInteger(index)
+        return self.app.getInteger(key)
 
-    def getKey(self, index: int) -> int:
-        """Gets the ID of the key provided by index."""
-        return self.app.getKey(index)
-
-    def getLargeInteger(self, index: int) -> int:
+    def getLargeInteger(self, key: int) -> int:
         """Gets the value of a key of type large integer."""
-        return self.app.getLargeInteger(index)
+        return self.app.getLargeInteger(key)
 
-    def getList(self, index: int) -> ActionList:
-        """Gets the value of a key of type list."""
-        return ActionList(self.app.getList(index))
+    @abstractmethod
+    def getList(self, key):
+        """Implemented in _actionmanager_type_binder.ActionDescriptor"""
+        pass
 
     def getObjectType(self, key: int) -> int:
         """Gets the class ID of an object in a key of type object."""
         return self.app.getObjectType(key)
 
-    def getObjectValue(self, key: int) -> int:
-        """Get the class ID of an object in a key of type object."""
-        return self.app.getObjectValue(key)
+    @abstractmethod
+    def getObjectValue(self, key):
+        """Implemented in _actionmanager_type_binder.ActionDescriptor"""
+        pass
 
-    def getPath(self, key: int) -> Path:
-        """Gets the value of a key of type."""
-        return Path(self.app.getPath(key))
+    def getPath(self, key: int) -> pathlib.Path:
+        """Gets the value of a key of type File."""
+        return pathlib.Path(self.app.getPath(key))
 
-    def getReference(self, key: int) -> ActionReference:
-        """Gets the value of a key of type."""
-        return ActionReference(self.app.getReference(key))
+    @abstractmethod
+    def getReference(self, key):
+        """Implemented in _actionmanager_type_binder.ActionDescriptor"""
+        pass
 
     def getString(self, key: int) -> str:
-        """Gets the value of a key of type."""
+        """Gets the value of a key of type string."""
         return self.app.getString(key)
 
-    def getType(self, key: int) -> DescValueType:
-        """Gets the type of a key."""
-        return DescValueType(self.app.getType(key))
+    @abstractmethod
+    def getType(self, key):
+        """Implemented in _actionmanager_type_binder.ActionDescriptor"""
+        pass
 
     def getUnitDoubleType(self, key: int) -> int:
         """Gets the unit type of a key of type UnitDouble."""
         return self.app.getUnitDoubleType(key)
 
-    def getUnitDoubleValue(self, key: int) -> int:
-        """Gets the unit type of a key of type UnitDouble."""
+    def getUnitDoubleValue(self, key: int) -> float:
+        """Gets the value of a key of type UnitDouble."""
         return self.app.getUnitDoubleValue(key)
-
-    def hasKey(self, key: int) -> bool:
-        """Checks whether the descriptor contains the provided key."""
-        return self.app.hasKey(key)
-
-    def isEqual(self, otherDesc) -> bool:
-        """Determines whether the descriptor is the same as another descriptor.
-
-        Args:
-            otherDesc (.action_descriptor.ActionDescriptor):
-
-        """
-        return self.app.isEqual(otherDesc)
 
     def putBoolean(self, key: int, value: bool):
         """Sets the value for a key whose type is boolean."""
@@ -162,50 +165,54 @@ class ActionDescriptor(Photoshop):
 
     def putData(self, key: int, value: str):
         """Puts raw byte data as a string value."""
-        self.app.putData(key, value)
+        warnings.warn(DATAFUNC_WARN, category=PendingDeprecationWarning)
+        try:
+            self.app.putData(key, value)
+        except BaseException:
+            pass
 
-    def putDouble(self, key: int, value: int):
+    def putDouble(self, key: int, value: float):
         """Sets the value for a key whose type is double."""
         self.app.putDouble(key, value)
 
-    def putEnumerated(self, key: int, enum_type: int, value: int):
+    def putEnumerated(self, key: int, enumType: int, value: int):
         """Sets the enumeration type and value for a key."""
-        self.app.putEnumerated(key, enum_type, value)
+        self.app.putEnumerated(key, enumType, value)
 
     def putInteger(self, key: int, value: int):
         """Sets the value for a key whose type is integer."""
-        self.app.putInteger(key, value)
+        if value.bit_length() <= 32:
+            self.app.putInteger(key, value)
+        else:
+            self.app.putLargeInteger(key, value)
 
     def putLargeInteger(self, key: int, value: int):
         """Sets the value for a key whose type is large integer."""
         self.app.putLargeInteger(key, value)
 
-    def putList(self, key: int, value: ActionList):
+    def putList(self, key: int, value):
         """Sets the value for a key whose type is an ActionList object."""
+        assert value.typename == "ActionList"
         self.app.putList(key, value)
 
-    def putObject(self, key: int, class_id: int, value):
-        """Sets the value for a key whose type is an object."""
-        self.app.putObject(key, class_id, value)
+    def putObject(self, key: int, classID: int, value):
+        """Sets the value for a key whose type is an object, represented by an Action Descriptor."""
+        assert value.typename == "ActionDescriptor"
+        self.app.putObject(key, classID, value)
 
-    def putPath(self, key: int, value: str):
+    def putPath(self, key: int, value: pathlib.Path):
         """Sets the value for a key whose type is path."""
-        self.app.putPath(key, value)
+        self.app.putPath(key, str(value))
 
-    def putReference(self, key: int, value: ActionReference):
+    def putReference(self, key: int, value):
         """Sets the value for a key whose type is an object reference."""
+        assert value.typename == "ActionReference"
         self.app.putReference(key, value)
 
     def putString(self, key: int, value: str):
         """Sets the value for a key whose type is string."""
         self.app.putString(key, value)
 
-    def putUnitDouble(self, key: int, unit_id: int, value: int):
-        """Sets the value for a key whose type is a unit value formatted as
-        double."""
-        self.app.putUnitDouble(key, unit_id, value)
-
-    def toStream(self) -> str:
-        """Gets the entire descriptor as as stream of bytes,
-        for writing to disk."""
-        return self.app.toSteadm()
+    def putUnitDouble(self, key: int, classID: int, value: float):
+        """Sets the value for a key whose type is a unit value formatted as a double."""
+        self.app.putUnitDouble(key, classID, value)

--- a/photoshop/api/action_list.py
+++ b/photoshop/api/action_list.py
@@ -4,54 +4,177 @@ It can be used for low-level access info Photoshop.
 
 
 """
+
+# Import built-in modules
+from abc import ABC
+from abc import abstractmethod
+import pathlib
+import warnings
+
+# Import third-party modules
+import comtypes
+
 # Import local modules
 from photoshop.api._core import Photoshop
 
 
-class ActionList(Photoshop):
-    """The list of commands that comprise an Action.
+DATAFUNC_WARN = """fromSteam, toStream, getData, putData is seldom performed successfully (even in native js, for
+example https://github.com/drsong2000/CRYENGINE/blob/release/Tools/photoshop/UltimateTextureSaver/Install/xtools/xlib/
+xml/atn2bin.jsx#L753-L769), and is deprecated. In fact, searching in github shows that these 4 functions are barely
+used in regular photoshop scripting. If you have found the criteria of these functions, please open an issue."""
 
-    (such as an Action created using the Actions palette in the Adobe Photoshop application).
-    The action list object is part of the Action Manager functionality.
-    For details on using the Action Manager, see the Photoshop Scripting Guide.
 
-    """
+class ActionList(Photoshop, ABC):
+    """This object provides an array-style mechanism for storing data. It can be used for low-level access into Photoshop.
+    This object is ideal when storing data of the same type. All items in the list must be of the same type."""
 
     object_name = "ActionList"
 
-    def __init__(self, parent=None):
+    def __init__(self, parent: comtypes.client.lazybind.Dispatch = None):
         super().__init__(parent=parent)
 
     @property
     def count(self):
         return self.app.count
 
-    def getBoolean(self, index):
+    def clear(self):
+        """Clears the list."""
+        self.app.clear()
+
+    def getBoolean(self, index: int) -> bool:
+        """Gets the value of a list element of type boolean."""
         return self.app.getBoolean(index)
 
-    def getClass(self, index):
+    def getClass(self, index: int) -> int:
+        """Gets the value of a list element of type class."""
         return self.app.getClass(index)
 
-    def getData(self, index):
-        return self.app.getData(index)
+    def getData(self, index: int) -> bytes:
+        """Gets raw byte data as a string value."""
+        warnings.warn(DATAFUNC_WARN, category=PendingDeprecationWarning)
+        try:
+            return self.app.getData(index)
+        except BaseException:
+            return None
 
-    def getDouble(self, index):
+    def getDouble(self, index: int) -> float:
+        """Gets the value of a list element of type double."""
         return self.app.getDouble(index)
 
-    def getEnumerationType(self, index):
+    def getEnumerationType(self, index: int) -> int:
+        """Gets the enumeration type of a list element."""
         return self.app.getEnumerationType(index)
 
-    def getEnumerationValue(self, index):
+    def getEnumerationValue(self, index: int) -> int:
+        """Gets the enumeration value of a list element."""
         return self.app.getEnumerationValue(index)
 
-    def getInteger(self, index):
+    def getInteger(self, index: int) -> int:
+        """Gets the value of a list element of type integer."""
         return self.app.getInteger(index)
 
-    def getLargeInteger(self, index):
+    def getLargeInteger(self, index: int) -> int:
+        """Gets the value of a list element of type large integer."""
         return self.app.getLargeInteger(index)
 
+    @abstractmethod
     def getList(self, index):
-        return self.app.getList(index)
+        """Implemented in _actionmanager_type_binder.ActionList"""
+        pass
 
-    def getObjectType(self, index):
+    def getObjectType(self, index: int) -> int:
+        """Gets the class ID of a list element of type object."""
         return self.app.getObjectType(index)
+
+    @abstractmethod
+    def getObjectValue(self, index):
+        """Implemented in _actionmanager_type_binder.ActionList"""
+        pass
+
+    def getPath(self, index: int) -> pathlib.Path:
+        """Gets the value of a list element of type File."""
+        return pathlib.Path(self.app.getPath(index))
+
+    @abstractmethod
+    def getReference(self, index):
+        """Implemented in _actionmanager_type_binder.ActionList"""
+        pass
+
+    def getString(self, index: int) -> str:
+        """Gets the value of a list element of type string."""
+        return self.app.getString(index)
+
+    @abstractmethod
+    def getType(self, index):
+        """Implemented in _actionmanager_type_binder.ActionList"""
+        pass
+
+    def getUnitDoubleType(self, index: int) -> int:
+        """Gets the unit value type of a list element of type Double."""
+        return self.app.getUnitDoubleType(index)
+
+    def getUnitDoubleValue(self, index: int) -> float:
+        """Gets the unit value of a list element of type double."""
+        return self.app.getUnitDoubleValue(index)
+
+    def putBoolean(self, value: bool):
+        """Appends a new value, true or false."""
+        self.app.putBoolean(value)
+
+    def putClass(self, value: int):
+        """Appends a new value, a class or data type."""
+        self.app.putClass(value)
+
+    def putData(self, value: bytes):
+        """Appends a new value, a string containing raw byte data."""
+        warnings.warn(DATAFUNC_WARN, category=PendingDeprecationWarning)
+        try:
+            self.app.putData(value)
+        except BaseException:
+            pass
+
+    def putDouble(self, value: float):
+        """Appends a new value, a double."""
+        self.app.putDouble(value)
+
+    def putEnumerated(self, enumType: int, value: int):
+        """Appends a new value, an enumerated (constant) value."""
+        self.app.putEnumerated(enumType, value)
+
+    def putInteger(self, value: int):
+        """Appends a new value, an integer."""
+        if value.bit_length() <= 32:
+            self.app.putInteger(value)
+        else:
+            self.app.putLargeInteger(value)
+
+    def putLargeInteger(self, value: int):
+        """Appends a new value, a large integer."""
+        self.app.putLargeInteger(value)
+
+    def putList(self, value):
+        """Appends a new value, a nested action list."""
+        assert value.typename == "ActionList"
+        self.app.putList(value)
+
+    def putObject(self, classID: int, value):
+        """Appends a new value, an object."""
+        assert value.typename == "ActionDescriptor"
+        self.app.putObject(classID, value)
+
+    def putPath(self, value: pathlib.Path):
+        """Appends a new value, a path."""
+        self.app.putPath(str(value))
+
+    def putReference(self, value):
+        """Appends a new value, a reference to an object created in the script."""
+        assert value.typename == "ActionReference"
+        self.app.putReference(value)
+
+    def putString(self, value: str):
+        """Appends a new value, a string."""
+        self.app.putString(value)
+
+    def putUnitDouble(self, classID: int, value: float):
+        """Appends a new value, a unit/value pair"""
+        self.app.putUnitDouble(classID, value)

--- a/photoshop/api/action_reference.py
+++ b/photoshop/api/action_reference.py
@@ -8,68 +8,82 @@ It can be used for low-level access into Contains data associated
 with an ActionDescriptor.
 
 """
+
+# Import built-in modules
+from abc import ABC
+from abc import abstractmethod
+
+# Import third-party modules
+import comtypes
+
 # Import local modules
 from photoshop.api._core import Photoshop
-from photoshop.api.enumerations import ReferenceFormType
 
 
-class ActionReference(Photoshop):
-    """Contains data describing a referenced Action.
-
-    The action reference object is part of the Action Manager functionality.
-    For details on using the Action Manager, see the Photoshop Scripting Guide.
-
-    """
-
+class ActionReference(Photoshop, ABC):
     object_name = "ActionReference"
 
-    def __init__(self, parent=None):
+    def __init__(self, parent: comtypes.client.lazybind.Dispatch = None):
         super().__init__(parent=parent)
 
+    @abstractmethod
     def getContainer(self):
-        return self.app.getContainer()
+        """Implemented in _actionmanager_type_binder.ActionReference"""
+        pass
 
-    def getDesiredClass(self):
+    def getDesiredClass(self) -> int:
+        """Gets a number representing the class of the object."""
         return self.app.getDesiredClass()
 
     def getEnumeratedType(self) -> int:
+        """Gets the enumeration type."""
         return self.app.getEnumeratedType()
 
     def getEnumeratedValue(self) -> int:
+        """Gets the enumeration value."""
         return self.app.getEnumeratedValue()
 
-    def getForm(self) -> ReferenceFormType:
-        """Gets the form of this action reference."""
-        return ReferenceFormType(self.app.getForm())
+    @abstractmethod
+    def getForm(self):
+        """Implemented in _actionmanager_type_binder.ActionReference"""
+        pass
 
     def getIdentifier(self) -> int:
-        """Gets the identifier value for a reference whose form is
-        identifier."""
+        """Gets the identifier value for a reference whose form is identifier."""
         return self.app.getIdentifier()
 
     def getIndex(self) -> int:
-        """Gets the index value for a reference in a list or array,"""
+        """Gets the index value for a reference in a list or array."""
         return self.app.getIndex()
 
-    def putName(self, key, value):
-        return self.app.putName(key, value)
+    def getName(self) -> str:
+        """Gets the name of a reference."""
+        return self.app.getName()
 
-    def putClass(self, value):
-        return self.app.putClass(value)
+    def getOffset(self) -> int:
+        """Gets the offset of the object’s index value."""
+        return self.app.getOffset()
 
-    def putEnumerated(self, desired_class, enum_type, value):
-        """Puts an enumeration type and ID into a reference along with the
-        desired class for the reference."""
-        return self.app.putEnumerated(desired_class, enum_type, value)
+    def getProperty(self) -> int:
+        return self.app.getProperty()
 
-    def putIdentifier(self, desired_class, value):
-        return self.app.putIdentifier(desired_class, value)
+    def putClass(self, desiredClass: int):
+        self.app.putClass(desiredClass)
 
-    def putIndex(self, desired_class, value):
-        return self.app.putIndex(desired_class, value)
+    def putEnumerated(self, desiredClass: int, enumType: int, value: int):
+        self.app.putEnumerated(desiredClass, enumType, value)
 
-    def putOffset(self, desired_class, value):
-        return self.app.putOffset(desired_class, value)
+    def putIdentifier(self, desiredClass: int, value: int):
+        self.app.putIdentifier(desiredClass, value)
 
-    def putProperty(self, desired_class, value):
-        return self.app.putProperty(desired_class, value)
+    def putIndex(self, desiredClass: int, value: int):
+        self.app.putIndex(desiredClass, value)
+
+    def putName(self, desiredClass: int, value: str):
+        self.app.putName(desiredClass, value)
+
+    def putOffset(self, desiredClass: int, value: int):
+        self.app.putOffset(desiredClass, value)
+
+    def putProperty(self, desiredClass: int, value: int):
+        self.app.putProperty(desiredClass, value)

--- a/photoshop/api/application.py
+++ b/photoshop/api/application.py
@@ -19,6 +19,7 @@ from typing import List
 from typing import Optional
 
 # Import local modules
+from photoshop.api._actionmanager_type_binder import ActionDescriptor
 from photoshop.api._artlayer import ArtLayer
 from photoshop.api._core import Photoshop
 from photoshop.api._document import Document
@@ -352,10 +353,12 @@ class Application(Photoshop):
         self.app.eraseCustomOptions(key)
 
     def executeAction(self, event_id, descriptor, display_dialogs=2):
-        return self.app.executeAction(event_id, descriptor, display_dialogs)
+        comobj = self.app.executeAction(event_id, descriptor, display_dialogs)
+        return ActionDescriptor(parent=comobj)
 
     def executeActionGet(self, reference):
-        return self.app.executeActionGet(reference)
+        comobj = self.app.executeActionGet(reference)
+        return ActionDescriptor(parent=comobj)
 
     def featureEnabled(self, name):
         """Determines whether the feature

--- a/photoshop/session.py
+++ b/photoshop/session.py
@@ -122,9 +122,9 @@ class Session:
         self._active_document = None
 
         self.app: Application = Application(version=ps_version)
-        self.ActionReference: ActionReference = ActionReference()
-        self.ActionDescriptor: ActionDescriptor = ActionDescriptor()
-        self.ActionList: ActionList = ActionList()
+        self.ActionReference: ActionReference = ActionReference
+        self.ActionDescriptor: ActionDescriptor = ActionDescriptor
+        self.ActionList: ActionList = ActionList
         self.EventID = EventID
         self.SolidColor = SolidColor
         self.TextItem = TextItem


### PR DESCRIPTION
There is a problem in the current AM part of this api:
When you use "get" functions, what you get **is** AM thing, but **not** an AM thing as well.
It **is** an AM thing: you can use those "put" and "get" functions documented in [Adobe's js scripting reference](https://raw.githubusercontent.com/Adobe-CEP/CEP-Resources/master/Documentation/Product%20specific%20Documentation/Photoshop%20Scripting/photoshop_scriptref_js-cc2014.pdf)
It is **not** an AM thing: It is just a COM bind object, using 'getType' will return number.
So I made this modification to unify.

Also, it seems that the functions written for the AM classes are not nessesary because it seems that COM bindings have already done that.