### PR TITLE
fix(TextItem.font): Change font to a read/write string property

### DIFF
--- a/photoshop/api/text_item.py
+++ b/photoshop/api/text_item.py
@@ -9,7 +9,6 @@ from photoshop.api.enumerations import StrikeThruType
 from photoshop.api.enumerations import TextComposer
 from photoshop.api.enumerations import TextType
 from photoshop.api.solid_color import SolidColor
-from photoshop.api.text_font import TextFont
 
 
 class TextItem(Photoshop):

--- a/photoshop/api/text_item.py
+++ b/photoshop/api/text_item.py
@@ -209,26 +209,31 @@ class TextItem(Photoshop):
         self.app.firstLineIndent = value
 
     @property
-    def font(self):
-        """.text_font.TextFont: Current font."""
-        return TextFont(self.app.font)
+    def font(self) -> str:
+        """str: postScriptName of the TextItem's font."""
+        return self.app.font
 
     @font.setter
-    def font(self, text_font):
+    def font(self, text_font: str):
+        """Set the font of this TextItem.
+
+        Args:
+            text_font (str): Must provide the postScriptName of a valid font.
+        """
         self.app.font = text_font
 
     @property
-    def hangingPunctuation(self):
-        """True to use Roman hanging punctuation."""
+    def hangingPunctuation(self) -> bool:
+        """bool: Whether to use Roman hanging punctuation."""
         return self.app.hangingPunctuation
 
     @hangingPunctuation.setter
-    def hangingPunctuation(self, value):
+    def hangingPunctuation(self, value: bool):
         self.app.hangingPunctuation = value
 
     @property
     def height(self):
-        """int:The height of the bounding box for paragraph text."""
+        """int: The height of the bounding box for paragraph text."""
         return self.app.height
 
     @height.setter
@@ -236,16 +241,17 @@ class TextItem(Photoshop):
         self.app.height = value
 
     @property
-    def horizontalScale(self):
-        """Character scaling (horizontal) in proportion to verticalScale
-
-        (a percentage value).
-
-        """
+    def horizontalScale(self) -> int:
+        """Character scaling (horizontal) in proportion to verticalScale (a percentage value)."""
         return self.app.horizontalScale
 
     @horizontalScale.setter
-    def horizontalScale(self, value):
+    def horizontalScale(self, value: int):
+        """Set the horizontalScale of this TextItem.
+
+        Args:
+            value: An integer between 0 and 1000.
+        """
         self.app.horizontalScale = value
 
     @property


### PR DESCRIPTION
## Problem
`TextItem.font` is currently returned as an inoperable `TextFont` object.

## Solution
Return the raw `TextItem.app.font` which is a string representing the postScriptName of the TextItem's font. This is the normal behavior according to the Photoshop Javascript Reference. Documentation segment attached below.

## Note
To set the font of a TextItem using a font existing in Photoshop, you can find the font by name using the `Application.fonts` collection and pass its postScriptName to `TextItem.font`, or provide the postScriptName manually if you know it.
```python
# TextFont from fonts collection
arial_bold = app.fonts.getByName('Arial Bold')
text_layer.textItem.font = arial_bold.postScriptName

# Providing a postScriptName manually
text_layer.textItem.font = 'Arial-Bold'
```
![image](https://github.com/loonghao/photoshop-python-api/assets/92750180/2d5405dd-940a-489c-9ef5-b26e244d1b3e)

## Other Changes
- Added some type annotations
- Improved some docstrings
